### PR TITLE
Request runtime permission to record audio for users on API 23+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,15 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 'android-17'
+    compileSdkVersion "android-25"
     buildToolsVersion '24.0.2'
 
     lintOptions {
 	disable 'IconDensities', 'ClickableViewAccessibility'
 	// abortOnError false
     }
+}
+
+dependencies {
+    compile 'com.android.support:support-compat:25.1.1'
 }

--- a/src/main/java/org/billthefarmer/tuner/MainActivity.java
+++ b/src/main/java/org/billthefarmer/tuner/MainActivity.java
@@ -23,6 +23,7 @@
 
 package org.billthefarmer.tuner;
 
+import android.Manifest;
 import android.app.ActionBar;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -31,11 +32,13 @@ import android.content.ClipboardManager;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.ActivityCompat;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -66,6 +69,8 @@ public class MainActivity extends Activity
 
     private static final String PREF_COLOUR = "pref_colour";
     private static final String PREF_CUSTOM = "pref_custom";
+
+    private static final int PERMISSIONS_REQUEST_RECORD_AUDIO = 1;
 
     // Note values for display
     private static final String notes[] =
@@ -362,6 +367,12 @@ public class MainActivity extends Activity
     protected void onStart()
     {
         super.onStart();
+
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+                != PackageManager.PERMISSION_GRANTED)
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.RECORD_AUDIO},
+                    PERMISSIONS_REQUEST_RECORD_AUDIO);
     }
 
     // On Resume
@@ -377,8 +388,21 @@ public class MainActivity extends Activity
         if (status != null)
             status.invalidate();
 
-        // Start the audio thread
-        audio.start();
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
+                == PackageManager.PERMISSION_GRANTED)
+            // Start the audio thread
+            audio.start();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           String permissions[], int[] grantResults)
+    {
+        if (requestCode == PERMISSIONS_REQUEST_RECORD_AUDIO)
+
+            // Permission denied
+            if (grantResults[0] == PackageManager.PERMISSION_DENIED)
+                showToast(R.string.permission_denied);
     }
 
     @Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -87,4 +87,6 @@
   <string name="pref_about">About</string>
   <string name="pref_about_summ">Tuner version %s</string>
 
+  <string name="permission_denied">Permission denied</string>
+
 </resources>


### PR DESCRIPTION
Updating the `targetSdkVersion` to a value above 22 enabled [runtime permissions](https://developer.android.com/guide/topics/permissions/requesting.html#perm-groups).

The changes in this Pull Request will prompt users on API 23 and above to allow the Record Audio permission required by this app. Users on API 22 or below maintain the same user experience (must accept permission(s) before installation proceeds).

I tried to keep the formatting style consistent with the rest of the codebase; feel free to reformat to your liking.

_As an alternative to the changes in this Pull Request, changing the `targetSdkVersion` on Line 13 in `AndroidManifest.xml` to 22 or below will revert to the old permission behavior._