### PR TITLE
Input source issues

### DIFF
--- a/src/main/java/org/billthefarmer/tuner/MainActivity.java
+++ b/src/main/java/org/billthefarmer/tuner/MainActivity.java
@@ -690,12 +690,29 @@ public class MainActivity extends Activity
         // Stop
         protected void stop()
         {
+            cleanUpAudioRecord();
+
             Thread t = thread;
             thread = null;
 
             // Wait for the thread to exit
             while (t != null && t.isAlive())
                 Thread.yield();
+        }
+
+        // Stop and release the audio recorder
+        private void cleanUpAudioRecord()
+        {
+            if (audioRecord != null && audioRecord.getState() == AudioRecord.STATE_INITIALIZED)
+            {
+
+                if (audioRecord.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING)
+                {
+                    audioRecord.stop();
+                }
+
+                audioRecord.release();
+            }
         }
 
         // Process Audio
@@ -835,10 +852,13 @@ public class MainActivity extends Activity
             while (thread != null)
             {
                 // Read a buffer of data
+                // NOTE: audioRecord.read(short[], int, int) can block
+                // indefinitely, until audioRecord.stop() is called
+                // from another thread
                 size = audioRecord.read(data, 0, STEP * divisor);
 
-                // Stop the thread if no data
-                if (size == 0)
+                // Stop the thread if no data or error state
+                if (size <= 0)
                 {
                     thread = null;
                     break;
@@ -1175,12 +1195,7 @@ public class MainActivity extends Activity
                 timer++;
             }
 
-            // Stop and release the audio recorder
-            if (audioRecord != null)
-            {
-                audioRecord.stop();
-                audioRecord.release();
-            }
+            cleanUpAudioRecord();
         }
 
         // Real to complex FFT, ignores imaginary values in input array

--- a/src/main/java/org/billthefarmer/tuner/MainActivity.java
+++ b/src/main/java/org/billthefarmer/tuner/MainActivity.java
@@ -745,11 +745,29 @@ public class MainActivity extends Activity
                 divisor = divisors[index];
 
                 // Create the AudioRecord object
-                audioRecord =
-                    new AudioRecord(input, rate,
+                try
+                {
+                    audioRecord =
+                            new AudioRecord(input, rate,
                                     AudioFormat.CHANNEL_IN_MONO,
                                     AudioFormat.ENCODING_PCM_16BIT,
                                     Math.max(size, SIZE * divisor));
+                }
+
+                catch (IllegalArgumentException e)
+                {
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            showAlert(R.string.app_name,
+                                    R.string.error_init);
+                        }
+                    });
+
+                    thread = null;
+                    return;
+                }
+
                 // Check state
                 state = audioRecord.getState();
                 if (state != AudioRecord.STATE_INITIALIZED)


### PR DESCRIPTION
I ran into two separate issues when trying the different "Input sources" in Settings.

1. On an API 25 device, selecting any of the "Voice call" audio sources and returning to the main screen threw an uncaught exception while constructing the [AudioRecord](https://developer.android.com/reference/android/media/AudioRecord.html#AudioRecord(int,%20int,%20int,%20int,%20int)) instance: 
```
java.lang.IllegalArgumentException: Invalid audio source.
	at android.media.AudioRecord.audioParamCheck(AudioRecord.java:680)
	at android.media.AudioRecord.<init>(AudioRecord.java:358)
	at android.media.AudioRecord.<init>(AudioRecord.java:278)
	at org.billthefarmer.tuner.MainActivity$Audio.processAudio(MainActivity.java:752)
	at org.billthefarmer.tuner.MainActivity$Audio.run(MainActivity.java:687)
	at java.lang.Thread.run(Thread.java:761)
```
This Pull Request wraps the constructor in a try-catch and displays the "... Maybe the selected input source is not available..." error dialog that was used in other failure cases.

2. On an API 19 device, selecting any of the "Voice call" audio sources and returning to the main screen blocked the `Audio` thread indefinitely on  `audioRecord.read(short[], int, int)` at Line 820. When going back to Settings to change the Input source, the application hangs on a black screen due to the main thread yielding at Line 698 while waiting for the `Audio` thread to exit.

This Pull Request has the main thread stop the `AudioRecord` instance, which unblocks the read call and allows the `Audio` thread to exit cleanly.