### PR TITLE
Change note spelling for the solfège option

### DIFF
--- a/src/main/java/org/billthefarmer/tuner/Display.java
+++ b/src/main/java/org/billthefarmer/tuner/Display.java
@@ -59,7 +59,7 @@ public class Display extends TunerView
     private static final String solfa[] =
     {
         "Do", "Do", "Re", "Mi", "Mi", "Fa",
-        "Fa", "So", "La", "La", "Ti", "Ti"
+        "Fa", "Sol", "La", "La", "Si", "Si"
     };
 
     private static final String sharps[] =


### PR DESCRIPTION
I have changed the names of the notes to the most widely used in the
fixed do solfège, as you can see in the Wikipedia [article][1], where the
only mention of "Ti" is in a single chromatic variant of the fixed do
solfège.

As I also use that in my daily life and studies, this change would help me.

Thanks for your work on this app! =)

[1]: https://en.m.wikipedia.org/wiki/Solf%C3%A8ge#Fixed_do_solf%C3%A8ge