### PR TITLE
Fix not working view when animations are disabled

### DIFF
--- a/src/main/java/org/billthefarmer/tuner/AAnimatedView.java
+++ b/src/main/java/org/billthefarmer/tuner/AAnimatedView.java
@@ -1,0 +1,65 @@
+package org.billthefarmer.tuner;
+
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+abstract public class AAnimatedView extends View
+    implements ValueAnimator.AnimatorUpdateListener
+{
+    /**
+     * Update the internal value used used for draw
+     * @param isAnimatorWorking is true if device animations are enabled
+     * @return return true if a invalidate method should be call
+     */
+    protected abstract boolean updateInternalValues(boolean isAnimatorWorking);
+
+    protected ValueAnimator animator;
+    private boolean isAnimatorWorking;
+
+    public AAnimatedView(Context context, AttributeSet attrs)
+    {
+        super(context, attrs);
+        isAnimatorWorking = false;
+    }
+
+    public void startAnimator()
+    {
+        // Create animator
+        animator = ValueAnimator.ofInt(0, 10000);
+        animator.setRepeatCount(ValueAnimator.INFINITE);
+        animator.setRepeatMode(ValueAnimator.RESTART);
+        animator.setDuration(10000);
+
+        // Update the display
+        animator.addUpdateListener(this);
+
+        // Start the animator
+        animator.start();
+    }
+
+    /**
+     * Manually trig animation
+     */
+    public void forceAnimationTrigger()
+    {
+        if (!isAnimatorWorking)
+        {
+            if (updateInternalValues(isAnimatorWorking))
+                postInvalidate();
+        }
+    }
+
+    // Animation update
+    @Override
+    public void onAnimationUpdate(ValueAnimator animator)
+    {
+        // Only two shots at value min and max if animator not working
+        int animatedValue = ((Integer)animator.getAnimatedValue()).intValue();
+        isAnimatorWorking |= (animatedValue > 0 && animatedValue < 10000);
+
+        if (updateInternalValues(isAnimatorWorking))
+            invalidate();
+    }
+}

--- a/src/main/java/org/billthefarmer/tuner/ColourPickerPreference.java
+++ b/src/main/java/org/billthefarmer/tuner/ColourPickerPreference.java
@@ -79,12 +79,14 @@ public class ColourPickerPreference extends DialogPreference
         {
             strobe.foreground = c;
             strobe.createShaders();
+            strobe.invalidate();
         });
 
         backgroundPicker.setListener(c ->
         {
             strobe.background = c;
             strobe.createShaders();
+            strobe.invalidate();
         });
     }
 

--- a/src/main/java/org/billthefarmer/tuner/MainActivity.java
+++ b/src/main/java/org/billthefarmer/tuner/MainActivity.java
@@ -285,6 +285,7 @@ public class MainActivity extends Activity
     private Meter meter;
     private Scope scope;
     private Staff staff;
+    private SignalView signal;
 
     private Audio audio;
     private Toast toast;
@@ -320,7 +321,7 @@ public class MainActivity extends Activity
         actionBar.setCustomView(R.layout.custom);
         actionBar.setDisplayShowCustomEnabled(true);
 
-        SignalView signal = findViewById(R.id.signal);
+        signal = findViewById(R.id.signal);
 
         // Create audio
         audio = new Audio();
@@ -1012,6 +1013,41 @@ public class MainActivity extends Activity
         // Show it
         dialog.show();
     }
+    
+    private void invalidateUserControls ()
+    {
+        // Update spectrum
+        if (spectrum != null && spectrum.isShown())
+            spectrum.postInvalidate();
+
+        // Update display
+        if (display != null && display.isShown())
+            display.postInvalidate();
+
+        // Update strobe
+        if (strobe != null && strobe.isShown())
+            strobe.forceAnimationTrigger();
+
+        // Update status
+        if (status != null && status.isShown())
+            status.postInvalidate();
+
+        // Update meter
+        if (meter != null && meter.isShown())
+            meter.forceAnimationTrigger();
+
+        // Update scope
+        if (scope != null && scope.isShown())
+            scope.postInvalidate();
+
+        // Update staff
+        if (staff != null && staff.isShown())
+            staff.postInvalidate();
+
+        // Update signal
+        if (signal != null && signal.isShown())
+            signal.forceAnimationTrigger();
+    }
 
     // Log2
     protected double log2(double d)
@@ -1648,17 +1684,7 @@ public class MainActivity extends Activity
                     // If display not locked
                     if (!lock)
                     {
-                        // Update spectrum
-                        if (spectrum != null)
-                            spectrum.postInvalidate();
-
-                        // Update display
-                        if (display != null)
-                            display.postInvalidate();
-
-                        // Update staff
-                        if (staff != null)
-                            staff.postInvalidate();
+                        invalidateUserControls();
                     }
 
                     // Reset count;
@@ -1680,18 +1706,14 @@ public class MainActivity extends Activity
                             count = 0;
                             note = 0;
 
-                            // Update display
-                            if (display != null)
-                                display.postInvalidate();
-
-                            // Update staff
-                            if (staff != null)
-                                staff.postInvalidate();
+                            invalidateUserControls();
                         }
-
-                        // Update spectrum
-                        if (spectrum != null)
-                            spectrum.postInvalidate();
+                        else
+                        {
+                            // Update spectrum
+                            if (spectrum != null)
+                                spectrum.postInvalidate();
+                        }
                     }
                 }
 

--- a/src/main/java/org/billthefarmer/tuner/SignalView.java
+++ b/src/main/java/org/billthefarmer/tuner/SignalView.java
@@ -23,7 +23,6 @@
 
 package org.billthefarmer.tuner;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
@@ -37,8 +36,7 @@ import android.util.AttributeSet;
 import android.view.View;
 
 // Signal view
-public class SignalView extends View
-    implements ValueAnimator.AnimatorUpdateListener
+public class SignalView extends AAnimatedView
 {
     protected MainActivity.Audio audio;
 
@@ -110,33 +108,23 @@ public class SignalView extends View
                          margin + w / 2, margin + height * 3 / 4);
 
         // Create animator
-        ValueAnimator animator = ValueAnimator.ofInt(0, 10000);
-        animator.setRepeatCount(ValueAnimator.INFINITE);
-        animator.setRepeatMode(ValueAnimator.RESTART);
-        animator.setDuration(10000);
-
-        // Update the display
-        animator.addUpdateListener(this);
-
-        // Start the animator
-        animator.start();
+        startAnimator();
     }
 
-    // Animation update
     @Override
-    public void onAnimationUpdate(ValueAnimator animator)
+    public boolean updateInternalValues(boolean isAnimatorWorking)
     {
-        // Do VU meter style calculation
-        if (audio != null)
+        boolean doInvalidate = false;
+        if (audio != null && signal != audio.signal)
         {
+            // Do VU meter style calculation
             if (signal < audio.signal)
                 signal = ((signal * 4) + audio.signal) / 5;
-
             else
                 signal = ((signal * 9) + audio.signal) / 10;
+            doInvalidate = true;
         }
-
-        invalidate();
+        return doInvalidate;
     }
 
     @Override

--- a/src/main/java/org/billthefarmer/tuner/Staff.java
+++ b/src/main/java/org/billthefarmer/tuner/Staff.java
@@ -23,7 +23,6 @@
 
 package org.billthefarmer.tuner;
 
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;

--- a/src/main/java/org/billthefarmer/tuner/StrobeView.java
+++ b/src/main/java/org/billthefarmer/tuner/StrobeView.java
@@ -88,7 +88,6 @@ public class StrobeView extends PreferenceView
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh)
     {
-
         width = w;
 
         // Calculate size

--- a/src/main/java/org/billthefarmer/tuner/TunerView.java
+++ b/src/main/java/org/billthefarmer/tuner/TunerView.java
@@ -36,7 +36,7 @@ import android.view.View;
 import android.util.Log;
 
 // Tuner View
-public abstract class TunerView extends View
+public abstract class TunerView extends AAnimatedView
 {
     protected MainActivity.Audio audio;
     protected Resources resources;
@@ -73,6 +73,12 @@ public abstract class TunerView extends View
         typedArray.recycle();
 
         paint = new Paint();
+    }
+
+    @Override
+    protected boolean updateInternalValues(boolean isAnimatorWorking)
+    {
+        return false;
     }
 
     // On Size Changed


### PR DESCRIPTION
This pull request will fix not working feature when animation are disabled. See [issue 56](https://github.com/billthefarmer/tuner/issues/56) for the bug description.

**In MainActivity**
- Do _updateUserControl_ function, centralize call to _invalidate_ or _forceAnimationTrigger_ methods.

**In SignalView / Staff / Strobe / Meter**
- Remove the ValueAnimator (now in parents _AAnimatedView_)
- Add _updateInternalValuesfunction_ for doing updating cents / signal / or other reported audio values. This function return true if the (post)invalidate method have to be called, ie if something have to been updated.
- The _updateInternalValuesfunction_  is called on _onAnimationUpdate_ when animator running, or through _forceAnimationTrigger_  if not running.

**In AAnimatedView :** 
- Factorize the value animator code. Animation are managed in this function. 
- If animations is working, the function will call the invalidate() on _valueAnimatorUpdated_()
- If animations are not working, a pseudo update will generated by calling _forceAnimationTrigger_(), called from _processAudio_ in main loop.
- Adjust inertia value if animations are not working.

**In TunerView**
- Change parent to AAnimatedView 
- Implements default _updateInternalValues_ function

**In StrobeView**
- Fix strobe view not updating after selecting a color.

Code have been tested with a galaxy S9e, running on android 12.

With best regards.